### PR TITLE
Added further customisation with default values

### DIFF
--- a/Example/JCTagListView/JCViewController.m
+++ b/Example/JCTagListView/JCViewController.m
@@ -21,7 +21,10 @@
 {
     [super viewDidLoad];
     
-    self.tagListView.canSeletedTags = YES;
+    self.tagListView.canSelectTags = YES;
+    self.tagView.tagStrokeColor = [UIColor redColor]; //(Optional)
+    self.tagView.tagBackgroundColor = [UIColor whiteColor]; //(Optional)
+    self.tagView.tagTextColor = [UIColor redColor]; //(Optional)
     self.tagListView.tagColor = [UIColor darkGrayColor];
     self.tagListView.tagCornerRadius = 5.0f;
     

--- a/Example/JCTagListView/JCViewController.m
+++ b/Example/JCTagListView/JCViewController.m
@@ -22,10 +22,11 @@
     [super viewDidLoad];
     
     self.tagListView.canSelectTags = YES;
-    self.tagListView.tagStrokeColor = [UIColor redColor]; //(Optional)
+    self.tagListView.tagStrokeColor = [UIColor darkGrayColor]; //(Optional)
     self.tagListView.tagBackgroundColor = [UIColor whiteColor]; //(Optional)
-    self.tagListView.tagTextColor = [UIColor redColor]; //(Optional)
-    self.tagListView.tagColor = [UIColor darkGrayColor];
+    self.tagListView.tagTextColor = [UIColor darkGrayColor]; //(Optional)
+    // Previous method:
+    // self.tagListView.tagColor = [UIColor darkGrayColor];
     self.tagListView.tagCornerRadius = 5.0f;
     
     [self.tagListView.tags addObjectsFromArray:@[@"NSString", @"NSMutableString", @"NSArray", @"UIAlertView", @"UITapGestureRecognizer", @"IBOutlet", @"IBAction", @"id", @"UIView", @"UIStatusBar", @"UITableViewController", @"UIStepper", @"UISegmentedControl", @"UICollectionViewController", @"UISearchBar", @"UIToolbar", @"UIPageControl", @"UIActionSheet", @"NSMutableArray", @"NSDictionary", @"NSMutableDictionary", @"NSSet", @"NSMutableSet", @"NSData", @"NSMutableData", @"NSDate", @"NSCalendar", @"UIButton", @"UILabel", @"UITextField", @"UITextView", @"UIImageView", @"UITableView", @"UICollectionView", @"UIViewController"]];

--- a/Example/JCTagListView/JCViewController.m
+++ b/Example/JCTagListView/JCViewController.m
@@ -22,9 +22,9 @@
     [super viewDidLoad];
     
     self.tagListView.canSelectTags = YES;
-    self.tagView.tagStrokeColor = [UIColor redColor]; //(Optional)
-    self.tagView.tagBackgroundColor = [UIColor whiteColor]; //(Optional)
-    self.tagView.tagTextColor = [UIColor redColor]; //(Optional)
+    self.tagListView.tagStrokeColor = [UIColor redColor]; //(Optional)
+    self.tagListView.tagBackgroundColor = [UIColor whiteColor]; //(Optional)
+    self.tagListView.tagTextColor = [UIColor redColor]; //(Optional)
     self.tagListView.tagColor = [UIColor darkGrayColor];
     self.tagListView.tagCornerRadius = 5.0f;
     

--- a/Pod/Classes/JCTagListView.h
+++ b/Pod/Classes/JCTagListView.h
@@ -17,7 +17,7 @@ typedef void (^JCTagListViewBlock)(NSInteger index);
 @property (nonatomic, strong) UIColor *tagBackgroundColor;
 @property (nonatomic, assign) CGFloat tagCornerRadius;
 
-@property (nonatomic, assign) BOOL canSeletedTags;
+@property (nonatomic, assign) BOOL canSelectTags;
 
 @property (nonatomic, strong) NSMutableArray *tags;
 @property (nonatomic, strong, readonly) NSMutableArray *seletedTags;

--- a/Pod/Classes/JCTagListView.h
+++ b/Pod/Classes/JCTagListView.h
@@ -12,7 +12,9 @@ typedef void (^JCTagListViewBlock)(NSInteger index);
 
 @interface JCTagListView : UIView
 
-@property (nonatomic, strong) UIColor *tagColor;
+@property (nonatomic, strong) UIColor *tagStrokeColor;
+@property (nonatomic, strong) UIColor *tagTextColor;
+@property (nonatomic, strong) UIColor *tagBackgroundColor;
 @property (nonatomic, assign) CGFloat tagCornerRadius;
 
 @property (nonatomic, assign) BOOL canSeletedTags;

--- a/Pod/Classes/JCTagListView.m
+++ b/Pod/Classes/JCTagListView.m
@@ -20,6 +20,56 @@
 
 static NSString * const reuseIdentifier = @"tagListViewItemId";
 
+@synthesize tagStrokeColor = _tagStrokeColor;
+
+-(void)setTextColor:(UIColor *)tagStrokeColor
+{
+    _tagStrokeColor = tagStrokeColor;
+}
+
+-(UIColor *) tagStrokeColor
+{
+    if(_tagStrokeColor){
+        return _tagStrokeColor;
+    }else{
+        return [UIColor lightGrayColor];
+    }
+}
+
+
+@synthesize tagTextColor = _tagTextColor;
+
+-(void)setTagTextColor:(UIColor *)tagTextColor
+{
+    _tagTextColor = tagTextColor;
+}
+
+-(UIColor *) tagTextColor
+{
+    if(_tagTextColor){
+        return _tagTextColor;
+    }else{
+        return [UIColor whiteColor];
+    }
+}
+
+@synthesize tagBackgroundColor = _tagBackgroundColor;
+
+
+-(void)setTagBackgroundColor:(UIColor *)tagBackgroundColor
+{
+    _tagBackgroundColor = tagBackgroundColor;
+}
+
+-(UIColor *) tagBackgroundColor
+{
+    if(_tagBackgroundColor){
+        return _tagBackgroundColor;
+    }else{
+        return [UIColor clearColor];
+    }
+}
+
 - (id)initWithFrame:(CGRect)frame
 {
     if (self = [super initWithFrame:frame]) {
@@ -51,7 +101,7 @@ static NSString * const reuseIdentifier = @"tagListViewItemId";
     
     self.tags = [NSMutableArray array];
     
-    self.tagColor = [UIColor darkGrayColor];
+    self.tagStrokeColor = [UIColor darkGrayColor];
     self.tagCornerRadius = 10.0f;
     
     JCCollectionViewTagFlowLayout *layout = [[JCCollectionViewTagFlowLayout alloc] init];
@@ -61,7 +111,7 @@ static NSString * const reuseIdentifier = @"tagListViewItemId";
     self.collectionView.dataSource = self;
     self.collectionView.showsHorizontalScrollIndicator = NO;
     self.collectionView.showsVerticalScrollIndicator = NO;
-    self.collectionView.backgroundColor = [UIColor whiteColor];
+    self.collectionView.backgroundColor = [UIColor clearColor];
     [self.collectionView registerClass:[JCTagCell class] forCellWithReuseIdentifier:reuseIdentifier];
     [self addSubview:self.collectionView];
 }
@@ -91,11 +141,11 @@ static NSString * const reuseIdentifier = @"tagListViewItemId";
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
     JCTagCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:reuseIdentifier forIndexPath:indexPath];
-    cell.backgroundColor = [UIColor whiteColor];
-    cell.layer.borderColor = self.tagColor.CGColor;
+    cell.backgroundColor = self.tagBackgroundColor;
+    cell.layer.borderColor = self.tagStrokeColor.CGColor;
     cell.layer.cornerRadius = self.tagCornerRadius;
     cell.titleLabel.text = self.tags[indexPath.item];
-    cell.titleLabel.textColor = self.tagColor;
+    cell.titleLabel.textColor = self.tagTextColor;
     
     return cell;
 }
@@ -106,7 +156,7 @@ static NSString * const reuseIdentifier = @"tagListViewItemId";
         JCTagCell *cell = (JCTagCell *)[collectionView cellForItemAtIndexPath:indexPath];
         
         if ([_seletedTags containsObject:self.tags[indexPath.item]]) {
-            cell.backgroundColor = [UIColor whiteColor];
+            cell.backgroundColor = [UIColor clearColor];
             
             [_seletedTags removeObject:self.tags[indexPath.item]];
         }

--- a/Pod/Classes/JCTagListView.m
+++ b/Pod/Classes/JCTagListView.m
@@ -152,7 +152,7 @@ static NSString * const reuseIdentifier = @"tagListViewItemId";
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (self.canSeletedTags) {
+    if (self.canSelectTags) {
         JCTagCell *cell = (JCTagCell *)[collectionView cellForItemAtIndexPath:indexPath];
         
         if ([_seletedTags containsObject:self.tags[indexPath.item]]) {


### PR DESCRIPTION
Added much clearer customisation options:

```
//Stroke color - Default: lightGreyColor
@property (nonatomic, strong) UIColor *tagStrokeColor; 

//Tag text color - Default: whiteColor
@property (nonatomic, strong) UIColor *tagTextColor;

//Background of tag color - Default: clearColor
@property (nonatomic, strong) UIColor *tagBackgroundColor;
```

A `JCTagListView` can now be used to defined its tags styles as follows:

```
 @interface DetailViewController ()
 @property (weak, nonatomic) IBOutlet JCTagListView *tagView;
 @end 

- (void)viewDidLoad {
    [super viewDidLoad];
    self.tagView.canSelectTags = NO; //Spelling of method corrected
    self.tagView.tagStrokeColor = [UIColor redColor]; //(Now Optional)
    self.tagView.tagBackgroundColor = [UIColor whiteColor]; //(Now Optional)
    self.tagView.tagTextColor = [UIColor redColor]; //(Now Optional)
    self.tagView.tagCornerRadius = 4.0f;
    self.tagView.tags = [@[@"A",@"B",@"C"] mutableCopy];
}
```

Omitting these optional fields sets them to use the default values.
